### PR TITLE
Return False if network is not in networks

### DIFF
--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -68,7 +68,7 @@ class DockerCompose:
         return self.call('docker service ls -f name={} | tail -n +2'.format(self.project_prefix(service)))
 
     def is_external_network(self, network):
-        return isinstance(self.networks[network], dict) and 'external' in self.networks[network]
+        return isinstance(self.networks[network], dict) and 'external' in self.networks[network] if network in self.networks else False
 
     def up(self):
         for network in self.networks:


### PR DESCRIPTION
If network is not in the list networks, return False for
is_external_network(). Otherwise, a KeyError occurs.

Resolves #6.